### PR TITLE
Wrap Net:HTTP with OpenURI to handle redirects 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/lib/noaa.rb
+++ b/lib/noaa.rb
@@ -2,6 +2,8 @@ begin
   require 'time'
   require 'nokogiri'
   require 'geokit'
+  require 'libxml'
+  require 'open-uri'
 rescue LoadError => e
   if require 'rubygems' then retry
   else raise(e)

--- a/lib/noaa.rb
+++ b/lib/noaa.rb
@@ -12,7 +12,7 @@ end
 
 %w(current_conditions forecast forecast_day http_service station station_writer).each { |file| require File.join(File.dirname(__FILE__), 'noaa', file) }
 
-# 
+#
 # The NOAA singleton provides methods to conveniently access information from the NOAA weather feed.
 # For the most part, NOAA.current_conditions and NOAA.forecast will be the only entry point into the
 # NOAA API you will need; one exception is discussed below.
@@ -21,7 +21,7 @@ module NOAA
   autoload :VERSION, File.join(File.dirname(__FILE__), 'noaa', 'version')
 
   class <<self
-    # 
+    #
     # Retrieve the current weather conditions for a given latitude and longitude. Returns an
     # instance of NOAA::CurrentConditions.
     #
@@ -36,8 +36,8 @@ module NOAA
     def current_conditions(lat, lng)
       current_conditions_at_station(Station.closest_to(lat, lng).id)
     end
-    
-    # 
+
+    #
     # Retrieve the current weather conditions for a given weather station ID. Returns an
     # instance of NOAA::CurrentConditions.
     #
@@ -49,7 +49,7 @@ module NOAA
       CurrentConditions.from_xml(HttpService.new.get_current_conditions(station_id))
     end
 
-    # 
+    #
     # Retrieve daily forecast information for a given latitude and longitude. Returns
     # an instance of NOAA::Forecast.
     #

--- a/lib/noaa/current_conditions.rb
+++ b/lib/noaa/current_conditions.rb
@@ -1,5 +1,5 @@
 module NOAA
-  # 
+  #
   # Representation of the current conditions for a given observation point.
   #
   class CurrentConditions
@@ -31,7 +31,7 @@ module NOAA
     end
     alias_method :weather_summary, :weather_description
 
-    # 
+    #
     # NWS code representing weather type. This distills the #weather_description
     # into one of a much more manageable set of possibilities. Possible values are:
     #
@@ -67,7 +67,7 @@ module NOAA
       @weather_type_code ||= text_from_node('icon_url_name').gsub(/^n|\.jpg$/, '').to_sym
     end
 
-    # 
+    #
     # Return the NWS image URL for the current weather as string
     #
     def image_url
@@ -85,42 +85,42 @@ module NOAA
       text_from_node_with_unit('temp', unit, :f, :c).to_i
     end
 
-    # 
+    #
     # The current relative humidity percentage (0-100)
     #
     def relative_humidity
       text_from_node('relative_humidity').to_i
     end
 
-    # 
+    #
     # The current cardinal or ordinal direction that the wind is coming from (e.g., "Northwest")
     #
     def wind_direction
       text_from_node('wind_dir')
     end
 
-    # 
+    #
     # The current direction that the wind is coming from degrees (e.g. 330)
     #
     def wind_degrees
       text_from_node('wind_degrees').to_i
     end
 
-    # 
+    #
     # The current wind speed in miles per hour as a float (e.g., 3.45)
     #
     def wind_speed
       text_from_node('wind_mph').to_f
     end
 
-    # 
+    #
     # The current wind gust in miles per hour as a float, or nil if none
     #
     def wind_gust
       text_from_node('wind_gust_mph').to_f
     end
 
-    # 
+    #
     # The current barometric pressure
     #
     #   conditions.pressure       #=> pressure in inches
@@ -131,7 +131,7 @@ module NOAA
       text_from_node_with_unit('pressure', unit, :in, :mb).to_f
     end
 
-    # 
+    #
     # The current dew point.
     #
     #   conditions.dew_point           #=> dew point in fahrenheit
@@ -142,7 +142,7 @@ module NOAA
       text_from_node_with_unit('dewpoint', unit, :f, :c).to_i
     end
 
-    # 
+    #
     # The current heat index
     #
     #   conditions.heat_index           #=> heat index in fahrenheit
@@ -153,7 +153,7 @@ module NOAA
       text_from_node_with_unit('heat_index', unit, :f, :c).to_i
     end
 
-    # 
+    #
     # The current wind chill
     #
     #   conditions.wind_chill           #=> wind chill in fahrenheit
@@ -164,7 +164,7 @@ module NOAA
       text_from_node_with_unit('windchill', unit, :f, :c).to_i
     end
 
-    # 
+    #
     # The current visibility in miles
     #
     def visibility

--- a/lib/noaa/forecast.rb
+++ b/lib/noaa/forecast.rb
@@ -1,11 +1,11 @@
 module NOAA
-  # 
+  #
   # A Forecast object represents a multi-day forecast for a particular place. The forecast for a given day can
   # be accessed using the [] method; e.g. (assuming +forecast+ is a forecast for 12/20/2008 - 12/24/2008):
   #
   #   forecast[1]     #=> ForecastDay for 12/21/2008
   #   forecast.length #=> 4
-  #   
+  #
   class Forecast
 
     class <<self
@@ -20,18 +20,18 @@ module NOAA
       @doc = doc
     end
 
-    # 
+    #
     # The number of days provided by the forecast
     #
     def length
       @length ||= @doc.find(%q{/dwml/data/time-layout[@summarization='24hourly'][1]/start-valid-time}).length
     end
 
-    # 
+    #
     # Get the ForecastDay for day i
     #
     #   forecast[1] #=> returns the ForecastDay for the second day
-    # 
+    #
     def [](i)
       forecast_days[i]
     end

--- a/lib/noaa/forecast_day.rb
+++ b/lib/noaa/forecast_day.rb
@@ -1,5 +1,5 @@
 module NOAA
-  # 
+  #
   # A ForecastDay contains forecast data for a single day. Each day should start at 6am and
   # end at 6am the following day (assuming that is invariant on the part of the NOAA's data
   # feed). ForecastDay objects are accessed using NOAA::Forecast#[]

--- a/lib/noaa/http_service.rb
+++ b/lib/noaa/http_service.rb
@@ -5,15 +5,19 @@ module NOAA
     end
 
     def get_current_conditions(station_id)
-      LibXML::XML::Document.string(@HTTP.get(URI.parse("http://www.weather.gov/xml/current_obs/#{station_id}.xml")))
+      LibXML::XML::Document.string(get_html_document("http://www.weather.gov/xml/current_obs/#{station_id}.xml"))
     end
 
     def get_forecast(num_days, lat, lng)
-      LibXML::XML::Document.string(@HTTP.get(URI.parse("http://www.weather.gov/forecasts/xml/sample_products/browser_interface/ndfdBrowserClientByDay.php?lat=#{lat}&lon=#{lng}&format=24+hourly&numDays=#{num_days}")))
+      LibXML::XML::Document.string(get_html_document("http://www.weather.gov/forecasts/xml/sample_products/browser_interface/ndfdBrowserClientByDay.php?lat=#{lat}&lon=#{lng}&format=24+hourly&numDays=#{num_days}"))
     end
 
     def get_station_list
-      LibXML::XML::Document.string(@HTTP.get(URI.parse("http://www.weather.gov/xml/current_obs/index.xml")))
+      LibXML::XML::Document.string(get_html_document("http://www.weather.gov/xml/current_obs/index.xml"))
+    end
+
+    def get_html_document(url)
+      open(url).read
     end
   end
 end

--- a/lib/noaa/station.rb
+++ b/lib/noaa/station.rb
@@ -1,5 +1,5 @@
 module NOAA
-  # 
+  #
   # Data about an NOAA observation station. When accessing current conditions, the NOAA XML API
   # takes a station ID as input; thus, to find the current conditions for an arbitrary location, one
   # must first determine the closest weather station to that location. The NOAA.current_conditions
@@ -25,7 +25,7 @@ module NOAA
         stations.find { |station| station.id == id }
       end
 
-      # 
+      #
       # Find the station closest to a given location. Can accept arguments in any of the following
       # three forms (all are equivalent):
       #
@@ -82,10 +82,10 @@ module NOAA
 
     # Station name (e.g., "New York City, Central Park")
     attr_reader :name
-    
+
     # Two-digit abbreviation for state in which station resides (e.g., "NY")
     attr_reader :state
-    
+
     attr_reader :xml_url #:nodoc:
 
     def initialize(properties)
@@ -94,7 +94,7 @@ module NOAA
       end
       @coordinates = GeoKit::LatLng.new(properties['latitude'], properties['longitude'])
     end
-    
+
     # Latitude of station
     def latitude
       @coordinates.lat


### PR DESCRIPTION
The hardcoded URLs in HttpService will redirect, which plain Net::HTTP cannot handle. By wrapping Net::HTTP with [OpenURI](http://ruby-doc.org/stdlib-2.1.0/libdoc/open-uri/rdoc/OpenURI.html), HttpService will be able to handle these redirects. 

Fixes #4
