### PR TITLE
Allows for more flexible configuration of  station

### DIFF
--- a/lib/noaa.rb
+++ b/lib/noaa.rb
@@ -8,7 +8,7 @@ rescue LoadError => e
   end
 end
 
-%w(current_conditions forecast forecast_day http_service station station_writer).each { |file| require File.join(File.dirname(__FILE__), 'noaa', file) }
+%w(configuration current_conditions forecast forecast_day http_service station station_writer).each { |file| require File.join(File.dirname(__FILE__), 'noaa', file) }
 
 # 
 # The NOAA singleton provides methods to conveniently access information from the NOAA weather feed.
@@ -58,6 +58,18 @@ module NOAA
     #
     def forecast(num_days, lat, lng)
       Forecast.from_xml(HttpService.new.get_forecast(num_days, lat, lng))
+    end
+
+    def configure
+      yield configuration if block_given?
+    end
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    def default_station
+      configuration.station
     end
   end
 end

--- a/lib/noaa/configuration.rb
+++ b/lib/noaa/configuration.rb
@@ -1,0 +1,13 @@
+require 'yaml'
+module NOAA
+  class Configuration
+    attr_accessor :station
+
+    def load_with_hash(hash)
+      hash.each do |k, v|
+        setter_command = "#{k}="
+        send(setter_command, v) if respond_to? setter_command
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allows for flexible configuration of the gem through passing a block `(NOAA.configure { |config| config.station = 'TAPA' }` or by direct calls to the configuration object `(NOAA.configuration.station = 'TAPA')`
